### PR TITLE
Fix paths to TRACEUR and TRACEUR_RUNTIME on OS X.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-TRACEUR_RUNTIME=$(shell dirname `which traceur`)/bin/traceur.js
+TRACEUR=$(shell which traceur)
+TRACEUR_REAL=$(shell perl -e 'use Cwd "abs_path";print abs_path(shift)' $(TRACEUR))
+TRACEUR_RUNTIME=$(shell dirname $(TRACEUR_REAL))/bin/traceur.js
 BUILD=build
 
 $(BUILD)/demo.js: underscore.js $(TRACEUR_RUNTIME) $(BUILD)/traceur.init.out.js $(BUILD)/solver.out.js $(BUILD)/dict.out.js


### PR DESCRIPTION
For me, traceur is installed via `npm install -g traceur` and is located at /usr/local/bin/traceur, which is a symlink to /usr/local/lib/node_modules/traceur/traceur.
